### PR TITLE
修复转换器参数类型声明不正确的问题，修复rawResponse取值不正确的问题，添加更新默认值的方法。

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.7.0
 
 - fix:修复 useRestListApi 的 crud 响应转换器类型声明错误
+- breakchange: rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.7.0
+
+- fix:修复 useRestListApi 的 crud 响应转换器类型声明错误
+
 ## v0.6.0
 
 - feat: 添加删除数据响应转换器`transformRemoveResponse`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix:修复 useRestListApi 的 crud 响应转换器类型声明错误
 - breakchange: rawResponse 在有转换器的情况下返回值是直接获取来的数据而不是转换后的数据
+- improve: 添加`setDefaultSearchParams`方法更新默认查询条件
 
 ## v0.6.0
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ T[]
 - `transformSaveResponse` - 指定新增数据的响应数据转换器。
 - `transformUpdateRequest` - 指定更新数据的请求数据转换器。
 - `transformUpdateResponse` - 指定更新数据的响应数据转换器。
-- `transformRemoveResponse`  - 指定删除数据的响应数据转换器。
+- `transformRemoveResponse` - 指定删除数据的响应数据转换器。
 
 转换器可以用来定制你的 API 细节。会用一个章节来介绍。
 
@@ -569,6 +569,9 @@ dataSource.removeItemById('3');
 
 // 删除多条数据
 dataSource.removeItemsByIds(['1', '2', '3']);
+
+// 设置默认查询条件
+dataSource.setDefaultSearchParams({userName:'张三'});
 
 // 删除指定行的数据,从0开始
 dataSource.removeItemAt(5)

--- a/src/__test__/useRestListApi.spec.ts
+++ b/src/__test__/useRestListApi.spec.ts
@@ -318,8 +318,33 @@ it('rawResponse取的是原始响应数据', async () => {
       transformListReponse: (response) => response.data,
     }),
   );
-  result.current.fetch();
+
   await waitForNextUpdate();
+  expect(http.get).toHaveBeenCalledTimes(1);
 
   expect(result.current.rawResponse).toEqual(rawResponse);
+});
+
+it('设置默认查询条件', async () => {
+  (http.get as jest.Mock).mockResolvedValue([
+    { userId: '1', userName: '张三' },
+    { userId: '2', userName: '李四' },
+  ]);
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useRestListApi<any>('/test', [], {
+      keyName: 'userId',
+      defaultSearchParams: { userName: '张三' },
+    }),
+  );
+
+  await waitForNextUpdate();
+
+  expect(result.current.defaultSearchParams).toEqual({ userName: '张三' });
+  expect(result.current.searchParams).toEqual({ userName: '张三' });
+
+  result.current.setDefaultSearchParams({ userName: '李四' });
+
+  expect(http.get).toHaveBeenCalledTimes(2);
+  expect(result.current.defaultSearchParams).toEqual({ userName: '李四' });
+  expect(result.current.searchParams).toEqual({ userName: '李四' });
 });

--- a/src/__test__/useRestListApi.spec.ts
+++ b/src/__test__/useRestListApi.spec.ts
@@ -302,3 +302,24 @@ it('保存数据', async () => {
     { userId: '5', userName: '田七' },
   ]);
 });
+
+it('rawResponse取的是原始响应数据', async () => {
+  const rawResponse = {
+    data: [
+      { userId: '1', userName: '张三' },
+      { userId: '2', userName: '李四' },
+    ],
+  };
+  (http.get as jest.Mock).mockResolvedValue(rawResponse);
+
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useRestListApi<any>('/test', [], {
+      keyName: 'userId',
+      transformListReponse: (response) => response.data,
+    }),
+  );
+  result.current.fetch();
+  await waitForNextUpdate();
+
+  expect(result.current.rawResponse).toEqual(rawResponse);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import { HttpResponse, HttpRequestConfig } from '@sinoui/http';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { HttpRequestConfig } from '@sinoui/http';
 
 /**
  * 排序信息
@@ -45,7 +46,7 @@ export interface Options<T> {
   /**
    * 指定列表查询结果的转换器
    */
-  transformListReponse?: (response: HttpResponse) => any;
+  transformListReponse?: (response: any) => T[];
   /**
    * 指定查询条件转换器
    */
@@ -56,7 +57,7 @@ export interface Options<T> {
   /**
    * 指定获取单条数据的响应数据转换器
    */
-  transformFetchOneResponse?: (response: HttpResponse) => T;
+  transformFetchOneResponse?: (response: any) => T;
   /**
    * 指定新增数据的请求数据转换器
    */
@@ -64,7 +65,7 @@ export interface Options<T> {
   /**
    * 指定新增数据的响应数据转换器
    */
-  transformSaveResponse?: (response: HttpResponse) => T;
+  transformSaveResponse?: (response: any) => T;
   /**
    * 指定更新数据的请求数据转换器
    */
@@ -72,8 +73,8 @@ export interface Options<T> {
   /**
    * 指定更新数据的响应数据转换器
    */
-  transformUpdateResponse?: (response: HttpResponse) => T;
-   /**
+  transformUpdateResponse?: (response: any) => T;
+  /**
    * 指定删除数据的响应数据转换器
    */
   transformRemoveResponse?: (response: HttpRequestConfig) => void;

--- a/src/useRestListApi.ts
+++ b/src/useRestListApi.ts
@@ -82,7 +82,7 @@ function useRestListApi<T, RawResponse = T[]>(
           type: 'FETCH_SUCCESS',
           payload: { content: result, sorts },
         });
-        rawResponseRef.current = result as any;
+        rawResponseRef.current = response as any;
         return result;
       } catch (e) {
         dispatch({ type: 'FETCH_FAILURE' });

--- a/src/useRestListApi.ts
+++ b/src/useRestListApi.ts
@@ -75,7 +75,7 @@ function useRestListApi<T, RawResponse = T[]>(
         const response = await http.get<T[]>(requestUrl);
 
         const result = transformListReponse
-          ? transformListReponse(response as any)
+          ? transformListReponse(response)
           : response;
 
         dispatch({
@@ -251,7 +251,7 @@ function useRestListApi<T, RawResponse = T[]>(
       try {
         const response: T = await http.get(`${baseUrl}/${id}`);
         const result = transformFetchOneResponse
-          ? transformFetchOneResponse(response as any)
+          ? transformFetchOneResponse(response)
           : response;
 
         if (isNeedUpdate) {
@@ -285,7 +285,7 @@ function useRestListApi<T, RawResponse = T[]>(
           : itemInfo;
         const response: T = await http.post(baseUrl, info);
         const result = transformSaveResponse
-          ? transformSaveResponse(response as any)
+          ? transformSaveResponse(response)
           : response;
 
         if (isNeedUpdate) {
@@ -317,7 +317,7 @@ function useRestListApi<T, RawResponse = T[]>(
         const response: T = await http.put(`${baseUrl}/${info[keyName]}`, info);
 
         const result = transformUpdateResponse
-          ? transformUpdateResponse(response as any)
+          ? transformUpdateResponse(response)
           : response;
 
         if (isNeedUpdate) {


### PR DESCRIPTION
* 将转换器的参数类型改为`any`
* `rawResponse`取转换之前的原始数据
* 添加`setDefaultSearchParams`方法更新默认查询条件
